### PR TITLE
Ignore artifact files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/aegir-home
+/dockerfiles
+/documentation
+/hosting
+/hostmaster
+/provision
+/tests


### PR DESCRIPTION
After a successful docker install some directories are created not supposed to be added to git. Let's ignore those.

I'm not sure why the list contains other then the aegir-home **volume**
