### PR TITLE
Add a flag to the docker volume for compatibility with selinux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: strongpassword
     volumes:
-      - ./aegir-home:/var/aegir
+      - ./aegir-home:/var/aegir:Z
 
   database:
     image: mariadb


### PR DESCRIPTION
If this works with non-selinux, this would be a better fix than telling users to run `chcon` in the documentation.
