### PR TITLE
Fix typo in phpmyadmin port into 8081

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
   phpmyadmin:
     ports:
-    - 808:80
+    - 8081:80
     environment:
       MYSQL_ROOT_PASSWORD: longrandomsecurepassword
     tty: true


### PR DESCRIPTION
I changed the port num into 8081 **one** as the web is advised to use **8080**
